### PR TITLE
Add volume control to encoder at default keymap

### DIFF
--- a/keyboards/pikatea/keymaps/default/keymap.c
+++ b/keyboards/pikatea/keymaps/default/keymap.c
@@ -31,3 +31,14 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
         KC_NO,       KC_NO,      KC_NO,       KC_NO,      KC_NO
     )
 };
+
+#ifdef ENCODER_ENABLE
+void encoder_update_user(uint8_t index, bool clockwise) {
+    // Volume control
+    if (!clockwise) {
+        tap_code(KC_VOLU);
+    } else {
+        tap_code(KC_VOLD);
+    }
+}
+#endif


### PR DESCRIPTION
## Description

Add volume control to the encoder at default keymap

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [x] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation
